### PR TITLE
Use package version for server

### DIFF
--- a/src/mcp_gsuite/__init__.py
+++ b/src/mcp_gsuite/__init__.py
@@ -1,9 +1,17 @@
 from . import server
 import asyncio
+from importlib import metadata
+
+try:
+    __version__ = metadata.version("mcp-gsuite-enhanced")
+except metadata.PackageNotFoundError:  # pragma: no cover - fallback when package not installed
+    __version__ = "0.0.0"
+
 
 def main():
     """Main entry point for the package."""
     asyncio.run(server.main())
 
+
 # Optionally expose other important items at package level
-__all__ = ['main', 'server']
+__all__ = ["main", "server", "__version__"]

--- a/src/mcp_gsuite/server.py
+++ b/src/mcp_gsuite/server.py
@@ -13,6 +13,7 @@ import mcp.server.stdio
 from . import gauth
 from . import tools_gmail
 from . import tools_calendar
+from . import __version__
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -765,7 +766,7 @@ async def main():
             write_stream,
             InitializationOptions(
                 server_name="mcp-gsuite",
-                server_version="0.4.1",
+                server_version=__version__,
                 capabilities=server.get_capabilities(
                     notification_options=NotificationOptions(),
                     experimental_capabilities={},


### PR DESCRIPTION
## Summary
- provide `__version__` in package `__init__`
- use the package version for `server_version`

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_684d741c5d1c8332ab480c4eea6cbf48